### PR TITLE
Fix permission denied error in Codespace Container Creation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,11 @@
 FROM hashicorp/vault:latest
 
 # Install git
+USER root
+
 RUN apk add --no-cache git jq logrotate openssl
+
+RUN sed -i 's|/sbin/nologin|/bin/bash|g' /etc/passwd
 
 # Download and install latest Terraform
 RUN apk add --no-cache curl unzip && \
@@ -13,6 +17,8 @@ RUN apk add --no-cache curl unzip && \
     apk del curl unzip
     
 # Set environment variables for dev mode
+USER vault
+
 ENV VAULT_DEV_ROOT_TOKEN_ID=root
 ENV VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
   "build": {
     "dockerfile": "Dockerfile"
   },
+  "remoteUser": "root",
   "customizations": {
     "vscode": {
       "extensions": ["hashicorp.hcl"],


### PR DESCRIPTION
Fix the permission denied issue by adding the syntax in Dockerfile, such as 'USER root' before installing the package, 'RUN sed -i 's|/sbin/nologin|/bin/bash|g' /etc/passwd' to explicitly tell using bash, 'USER vault' to change back to vault user. I also added "remoteUser": "root" to devcontainer.json.

<img width="1761" height="868" alt="Screenshot 2026-04-27 110016" src="https://github.com/user-attachments/assets/fec4528e-5e06-48fa-bdf9-36bbabaeb16d" />
<img width="1919" height="867" alt="Screenshot 2026-04-27 105241" src="https://github.com/user-attachments/assets/37d98ec2-12d2-4b87-b1cb-6136dfbcef21" />
